### PR TITLE
CiteSeq samplesheet compatible with illumina v2 samplesheet

### DIFF
--- a/examples/CTG_SampleSheet.csv
+++ b/examples/CTG_SampleSheet.csv
@@ -28,12 +28,12 @@ sample-15,human,project8,n,n,n,atac,scatac-10x,n,n,n,n,n
 sample-16,human,project9,n,n,4,atac,scarc-10x,n,n,n,n,n
 sample-17,human,project9,n,n,4,gex,scarc-10x,n,n,n,n,n
 sample-18,human,project10,n,n,n,gex,scvisium-10x,cytaimage,darkimage,image,slide,slide_area
-[10X_Flex_Settings],,,,,,,,
+[FlexConfig_Data],,,,,,,,
 sample_id,probe_barcode,Sample_Source,,,,,,
 sample1,BC001|BC002,sample_7,,,,,,
 sample1,BC003|BC004,sample-8,,,,,,
-[10X_FeatureReference],,,,,,,,
-id,name,read,pattern,sequence,feature_type,Sample_Source,,
+[FeatureReference_Data],,,,,,,,
+id,name,read,pattern,sequence,feature_type,Sample_ID,,
 ADT_C0014,HuMs.CD11b,R2,5PNNNNNNNNNN(BC),TGAAGGCTCATTTGT,ADT,sample-4|sample-7,,
 ADT_C0073,HuMs.CD44,R2,5PNNNNNNNNNN(BC),TGGCTTCAGGTCCTA,ADT,sample-4|sample-7,,
 ADT_C0103,HuMs.CD45R_B220,R2,5P(BC),CCTACACCTCATAAT,ADT,sample-4|sample-7,,

--- a/modules/split_sheet/main.nf
+++ b/modules/split_sheet/main.nf
@@ -5,8 +5,8 @@ process SPLITSHEET {
     output:
         path "10X_Data.csv", emit: data
         path "Data.csv", emit: pipe_data, optional: true
-        path "10X_Flex_Settings.csv", emit: flex, optional: true
-        path "10X_FeatureReference.csv", emit: feature_reference, optional: true
+        path "FlexConfig_Data.csv", emit: flex, optional: true
+        path "FeatureReference_Data.csv", emit: feature_reference, optional: true
     shell:
     '''
     while read line; do

--- a/templates/manifest.html
+++ b/templates/manifest.html
@@ -83,7 +83,7 @@
     <div class="main-block">
       <div class="block-item">
         <h1><b>Nextflow manifest</b></h1>
-        <p> <b>Pipeline release:</b> 1.1.0</p>
+        <p> <b>Pipeline release:</b> 1.2.0</p>
         <p> <b>Subworkflow:</b> xxSubWorkflowxx</p>
         <p> <b> Maintainer:</b> jacob.karlstrom@med.lu.se</p>
         <p> <b>Description:</b> Your data has been processed by the nextflow pipeline singleCellWorkflows. If you want more information on how your data was processed, follow the link below and navigate to your release!</p>


### PR DESCRIPTION
FeatureReference header is now called FeatureReference_Data and contains the column Sample_ID, due to the illumina samplesheet v2 format requiring those two features. Otherwise Bclconvert crashes