### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Versions (please complete the following information):**
+ - OS: 
+ - Nextflow version:
+- Java version:
+- Singularity version:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE REQUEST]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**This issue can be closed when following goals are met **
+- [ ] Change this to a relevant goal that is well defined.
+- [ ] Sometimes we have more than one goal!

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+name: Stub run
+on: 
+  pull_request:
+    branches:
+    - master
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nf-core/setup-nextflow@v1
+      - run: echo "#0" > nextflow.log && nextflow run ${GITHUB_WORKSPACE} -stub --samplesheet ${GITHUB_WORKSPACE}/examples/CTG_SampleSheet.csv --outdir ${GITHUB_WORKSPACE}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: nf-core/setup-nextflow@v1
-      - run: echo "#0" > nextflow.log && nextflow run ${GITHUB_WORKSPACE} -stub --samplesheet ${GITHUB_WORKSPACE}/examples/CTG_SampleSheet.csv --outdir ${GITHUB_WORKSPACE}
+      - run: echo "#0" > nextflow.log && nextflow run ${GITHUB_WORKSPACE} -stub --samplesheet ${GITHUB_WORKSPACE}/examples/CTG_SampleSheet.csv --outdir ${GITHUB_WORKSPACE} -profile local_dev

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 CTG-Lund
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,10 @@
+## Background
+
+## Problem/Issue
+
+## What have I done
+
+## Check list
+I have:
+- [ ] Tested with Stub run
+- [ ] Tested on our HPC

--- a/nextflow.config
+++ b/nextflow.config
@@ -124,8 +124,8 @@ profiles {
 	local_dev {
 		process {
 			executor='local'
-			cpus='8'
-			memory='8 GB'
+			cpus='1'
+			memory='2 GB'
 			time='2d'
 		}
 		singularity {


### PR DESCRIPTION
## Background
Github is used to facilitate development of code by offering a suite of tools, one important one being issues.
## Problem/Issue
Issues are sometimes poorly defined and are hard to understand. This can happen because of multiple reasons, such as negligence, stress, or just not knowing better.
## What have I done
I have added issue templates for feature request and bug reports. They are very similar to the defeault templates available from github, with only some minor changes to be more specific towards the repo.
