### PR TITLE
Added nextflow conf for cellranger argument

### DIFF
--- a/modules/cellranger/count-arc/main.nf
+++ b/modules/cellranger/count-arc/main.nf
@@ -31,6 +31,7 @@ process COUNT_ARC {
 	     --reference=$genome \\
          --libraries=$library \\
 		 --localcores=19 --localmem=120 \\
+		 $params.cellranger_arguments
 
 	"""
 	stub:

--- a/modules/cellranger/count-atac/main.nf
+++ b/modules/cellranger/count-atac/main.nf
@@ -43,7 +43,7 @@ process COUNT_ATAC {
 	     --sample=$sample_id \\
 	     --reference=$genome \\
 		--localcores=19 --localmem=120 \\
-		 $forcecells $intron_argument
+		 $forcecells $intron_argument $params.cellranger_arguments
 
 	"""
 	stub:

--- a/modules/cellranger/count-citeseq/main.nf
+++ b/modules/cellranger/count-citeseq/main.nf
@@ -36,6 +36,7 @@ process COUNT {
          --feature-ref=$feature_reference \\
          --libraries=$library \\
 		 --localcores=19 --localmem=120 \\
+		 $params.cellranger_arguments
 
 	"""
 	stub:

--- a/modules/cellranger/count-rna/main.nf
+++ b/modules/cellranger/count-rna/main.nf
@@ -41,7 +41,7 @@ process COUNT {
 	     --sample $sample_id \\
 	     --transcriptome $genome \\
 		--localcores=19 --localmem 120 \\
-		 $forcecells $intron_argument
+		 $forcecells $intron_argument $params.cellranger_arguments
 
 	"""
 	stub:

--- a/modules/cellranger/multi/main.nf
+++ b/modules/cellranger/multi/main.nf
@@ -18,6 +18,7 @@ process MULTI {
 	     --id=$sample_id \\
          --csv=$config \\
 		--localcores=16 --localmem=120 \\
+		$params.cellranger_arguments
 	"""
 	stub:
 	"""

--- a/nextflow.config
+++ b/nextflow.config
@@ -43,6 +43,7 @@ params {
 	// runOptions
 	intron_mode="true"
 	ctg_mode="true"
+	cellranger_arguments=""
 	
 	deliver_to = "henning.onsbring@med.lu.se"
 


### PR DESCRIPTION
You can add a cellranger_arguments flag to manually input cellranger arguments when needed, like:
```
nexflow run main.nf --samplesheet /full/path/samplesheet.csv --cellranger_arguments "--force-cells=1000"
```
