### PR TITLE
pass check lib compatibility flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ nextflow run main.nf --samplesheet examples/CTG_SampleSheet.csv  \
 * [10X ATAC pipeline](/docs/scatac-10x.md)
 * [10X Multiome pipeline](/docs/scarc-10x.md)
 * [10X Visium pipeline](/docs/scvisium-10x.md)
+* [Contribution guide](docs/CONTRIBUTION.md)

--- a/docs/CONTRIBUTION.md
+++ b/docs/CONTRIBUTION.md
@@ -1,0 +1,65 @@
+# Contribution Guidelines
+
+Thank you for your interest in contributing to our project! We welcome contributions from everyone. To make the process as seamless as possible, we've outlined a set of guidelines to help you make the best possible contribution.
+
+## Table of Contents
+
+- [Contribution Guidelines](#contribution-guidelines)
+  - [Table of Contents](#table-of-contents)
+  - [Getting Started](#getting-started)
+    - [Issues](#issues)
+    - [Pull Requests](#pull-requests)
+  - [Coding Standards](#coding-standards)
+  - [Testing](#testing)
+  - [Documentation](#documentation)
+  - [Releases](#releases)
+
+
+## Getting Started
+
+### Issues
+
+- Before creating a new issue, please do a search to see if it has already been reported. If it has, add a comment to the existing issue instead of opening a new one.
+- Provide as much detail as possible when creating an issue. The more information, the easier it is for us to understand and address the problem.
+
+### Pull Requests
+
+- Make sure your PR is up-to-date with the main branch.
+- If you're adding a feature or fixing a bug, please add tests!
+- Describe what your PR does, the problem it solves, and reference any relevant issues.
+- Please keep your PRs as small and concise as possible. Larger PRs can be hard to review, making them more likely to have bugs and less likely to get merged.
+
+## Coding Standards
+
+- Follow the coding style of the project.
+- Include inline comments for important blocks of code.
+- Use meaningful commit messages. If you're unsure about what constitutes a good message, see [this guide](https://chris.beams.io/posts/git-commit/).
+
+## Testing
+
+- Make sure all tests pass before submitting a pull request.
+- Add new tests for every new feature or bug fix.
+- If possible, include a screenshot or gif of the new feature or bug fix in action.
+
+## Documentation
+
+- Update the README.md or any relevant documentation if necessary.
+- If you're adding a new feature, make sure to document it.
+- Use clear and concise language.
+
+
+## Releases
+
+When a pull request is approved to be merged into the master branch, it's essential to update the `manifest.html` file to reflect the new release tag. 
+
+Update the following lines in the `manifest.html` file:
+
+```html
+<p><b>Pipeline release:</b> Version.Major-release.Minor-release</p>
+<a href="https://github.com/ctg-lund/singleCellWorkflows/archive/refs/tags/Version.Major-release.Minor-release.tar.gz">
+```
+
+**Versioning Guidance:**
+- **Version**: Incorporate significant changes that might affect backward compatibility.
+- **Major Releases**:  These releases typically introduce new features that do not affect backward compability.
+- **Minor Releases**: Focus on bug fixes and slight optimizations without adding new features.

--- a/modules/cellranger/count-arc/main.nf
+++ b/modules/cellranger/count-arc/main.nf
@@ -14,6 +14,7 @@ process COUNT_ARC {
 		val Sample_Project, emit: project_id
 
 	script:
+	def args = task.ext.args ?: ''
 	// Get sample_specieserence
 	if ( sample_species == "Human" || sample_species == "human") {
 	   genome=params.human_atac }
@@ -31,7 +32,6 @@ process COUNT_ARC {
 	     --reference=$genome \\
          --libraries=$library \\
 		 --localcores=19 --localmem=120 \\
-		 $params.cellranger_arguments
 
 	"""
 	stub:

--- a/modules/cellranger/count-arc/main.nf
+++ b/modules/cellranger/count-arc/main.nf
@@ -14,7 +14,6 @@ process COUNT_ARC {
 		val Sample_Project, emit: project_id
 
 	script:
-	def args = task.ext.args ?: ''
 	// Get sample_specieserence
 	if ( sample_species == "Human" || sample_species == "human") {
 	   genome=params.human_atac }

--- a/modules/cellranger/count-atac/main.nf
+++ b/modules/cellranger/count-atac/main.nf
@@ -12,7 +12,6 @@ process COUNT_ATAC {
 		val project_id, emit: project_id
 
 	script:
-	def args = task.ext.args ?: ''
 	def filter = config.name != 'NO_FILE' ? "--filter $opt" : ''
 	// Set force-cells if force not "n"
 	forcecells=""

--- a/modules/cellranger/count-atac/main.nf
+++ b/modules/cellranger/count-atac/main.nf
@@ -12,6 +12,7 @@ process COUNT_ATAC {
 		val project_id, emit: project_id
 
 	script:
+	def args = task.ext.args ?: ''
 	def filter = config.name != 'NO_FILE' ? "--filter $opt" : ''
 	// Set force-cells if force not "n"
 	forcecells=""
@@ -43,7 +44,7 @@ process COUNT_ATAC {
 	     --sample=$sample_id \\
 	     --reference=$genome \\
 		--localcores=19 --localmem=120 \\
-		 $forcecells $intron_argument $params.cellranger_arguments
+		 $forcecells $intron_argument
 
 	"""
 	stub:

--- a/modules/cellranger/count-citeseq/main.nf
+++ b/modules/cellranger/count-citeseq/main.nf
@@ -16,6 +16,7 @@ process COUNT {
 		val Sample_ID, emit: sample_id
 
 	script:
+	def args = task.ext.args ?: ''
 	// Get sample_specieserence
 	if ( sample_species == "Human" || sample_species == "human") {
 	   genome=params.human }
@@ -36,7 +37,7 @@ process COUNT {
          --feature-ref=$feature_reference \\
          --libraries=$library \\
 		 --localcores=19 --localmem=120 \\
-		 --check-library-compatibility=false
+		 $args
 
 	"""
 	stub:

--- a/modules/cellranger/count-rna/main.nf
+++ b/modules/cellranger/count-rna/main.nf
@@ -11,7 +11,6 @@ process COUNT {
 		val project_id, emit: project_id
 
 	script:
-	def args = task.ext.args ?: ''
 	// Set force-cells if force not "n"
 	forcecells=""
 	if ( force != "n" && force != "null") {

--- a/modules/cellranger/count-rna/main.nf
+++ b/modules/cellranger/count-rna/main.nf
@@ -11,6 +11,7 @@ process COUNT {
 		val project_id, emit: project_id
 
 	script:
+	def args = task.ext.args ?: ''
 	// Set force-cells if force not "n"
 	forcecells=""
 	if ( force != "n" && force != "null") {
@@ -41,7 +42,7 @@ process COUNT {
 	     --sample $sample_id \\
 	     --transcriptome $genome \\
 		--localcores=19 --localmem 120 \\
-		 $forcecells $intron_argument $params.cellranger_arguments
+		 $forcecells $intron_argument
 
 	"""
 	stub:

--- a/modules/cellranger/multi/main.nf
+++ b/modules/cellranger/multi/main.nf
@@ -13,12 +13,13 @@ process MULTI {
 		val project_id, emit: project_id
 		
 	script:
+	def args = task.ext.args ?: ''
 	"""
 	cellranger multi \\
 	     --id=$sample_id \\
          --csv=$config \\
 		--localcores=16 --localmem=120 \\
-		$params.cellranger_arguments
+
 	"""
 	stub:
 	"""

--- a/modules/cellranger/multi/main.nf
+++ b/modules/cellranger/multi/main.nf
@@ -13,7 +13,6 @@ process MULTI {
 		val project_id, emit: project_id
 		
 	script:
-	def args = task.ext.args ?: ''
 	"""
 	cellranger multi \\
 	     --id=$sample_id \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,3 +1,9 @@
+// Global process
+process {
+    withName:"COUNT" {
+        ext.args = { $params.nolibcomp ? "--check-library-compatibility=false" : '' }
+    }
+}
 
 // Global params
 params {
@@ -43,7 +49,7 @@ params {
 	// runOptions
 	intron_mode="true"
 	ctg_mode="true"
-	cellranger_arguments=""
+	nolibcomp="false"
 	
 	deliver_to = "henning.onsbring@med.lu.se"
 

--- a/templates/manifest.html
+++ b/templates/manifest.html
@@ -112,7 +112,7 @@
       <div class="block-item">
         <h1><b>Nextflow manifest</b></h1>
         <br>
-        <p> <b>Pipeline release:</b> 1.6.0</p>
+        <p> <b>Pipeline release:</b> 1.6.1</p>
         <p> <b>Subworkflow:</b> xxSubWorkflowxx</p>
         <p> <b> Maintainer:</b> jacob.karlstrom@med.lu.se</p>
         <p> <b>Description:</b> Your data has been processed by the nextflow pipeline singleCellWorkflows. If you want more information on how your data was processed, follow the link below and navigate to your release!</p>
@@ -167,7 +167,7 @@
         <a href="https://github.com/ctg-lund/singleCellWorkflows/tree/master">
             <button class="btn github" data-provider="github"><i class="fab fa-github"></i><span>GitHub</span></button>
         </a>
-        <a href="https://github.com/ctg-lund/singleCellWorkflows/archive/refs/tags/v1.6.0.tar.gz">
+        <a href="https://github.com/ctg-lund/singleCellWorkflows/archive/refs/tags/v1.6.1.tar.gz">
           <button class="btn twitter" data-provider="twitter"><i class="fab "></i><span>Download pipeline release</span></button>
       </a>
       </div>


### PR DESCRIPTION
## Background
We need to be able to stop cellranger count from checking library compatibility

Inspiration for PR:
https://github.com/nf-core/rnaseq/blob/3.12.0/conf/modules.config
https://github.com/nf-core/rnaseq/blob/3.12.0/modules/nf-core/fastqc/main.nf
https://github.com/nf-core/raredisease/blob/1.1.1/conf/modules/align_sentieon.config

## Problem/Issue
If we cant pass the `--check-library-compatibility=false` flag then cellranger count will crash in some cases

## What have I done
Added support for passing the flag

## Check list
I have:
- [ ] Tested with Stub run
- [ ] Tested on our HPC
