### PR TITLE
also md5sum symlinks

### DIFF
--- a/modules/md5sum/main.nf
+++ b/modules/md5sum/main.nf
@@ -10,6 +10,7 @@ process MD5SUM {
 	"""
 	cd $params.outdir/${project_id}
 	find . -type f -exec md5sum '{}' \\; > ctg-md5.${project_id}.txt
+	find . -type l -exec md5sum '{}' \\; >> ctg-md5.${project_id}.txt
 	""" 
 	stub:
 	"""


### PR DESCRIPTION
## Background
We link fastq files into jobs instead of moving them

## Problem/Issue
The current md5sum generation won't generate md5sums for symlinks

## What have I done
Added a command that supports symlinks for md5sum generation

## Check list
I have:
- [ ] Tested with Stub run
- [ ] Tested on our HPC
