### PR TITLE
send bam flag

### DIFF
--- a/modules/cellranger/count-citeseq/main.nf
+++ b/modules/cellranger/count-citeseq/main.nf
@@ -29,11 +29,17 @@ process COUNT {
 	else {
 	   print ">ERROR: Species not recognized" 
 	   genome="ERR" }
+    if ( params.create_bam == 'true' ) {
+		create_bam="true"
+	} else {
+		create_bam="false"
+	}
 
 	"""
 	cellranger count \\
 	    --id=$Sample_ID \\
 	    --transcriptome=$genome \\
+	    --create-bam $create_bam \\
         --feature-ref=$feature_reference \\
         --libraries=$library \\
         --localcores=19 --localmem=120 \\


### PR DESCRIPTION
## Background
v8.0.0 require that you choose `--create-bam <true|false>`, there is no deafult

## Problem/Issue
We do not set this flag for SCCITESEQ:COUNT

## What have I done
Now `--create-bam` will be false unless true is specified

## Check list
I have:
- [ ] Tested with Stub run
- [ ] Tested on our HPC
