### PR TITLE
added create-bam flag

### DIFF
--- a/modules/cellranger/count-arc/main.nf
+++ b/modules/cellranger/count-arc/main.nf
@@ -24,13 +24,20 @@ process COUNT_ARC {
 	else {
 	   print ">ERROR: Species not recognized" 
 	   genome="ERR" }
+	
+	if ( params.create_bam == 'true' ) {
+		create_bam="true"
+	} else {
+		create_bam="false"
+	}
 
 	"""
 	cellranger-arc count \\
-	     --id=$Sample_ID \\
-	     --reference=$genome \\
-         --libraries=$library \\
-		 --localcores=19 --localmem=120 \\
+	    --id=$Sample_ID \\
+	    --reference=$genome \\
+        --libraries=$library \\
+		--create-bam $create_bam \\
+		--localcores=19 --localmem=120 \\
 
 	"""
 	stub:

--- a/modules/cellranger/count-atac/main.nf
+++ b/modules/cellranger/count-atac/main.nf
@@ -35,12 +35,19 @@ process COUNT_ATAC {
 	   print ">ERROR: Species not recognized" 
 	   genome="ERR" }
 
+	if ( params.create_bam == 'true' ) {
+		create_bam="true"
+	} else {
+		create_bam="false"
+	}
+
 	"""
 	cellranger-atac count \\
-	     --id=$sample_id \\
-	     --fastqs=$params.outdir/$project_id/fastq \\
-	     --sample=$sample_id \\
-	     --reference=$genome \\
+	    --id=$sample_id \\
+	    --fastqs=$params.outdir/$project_id/fastq \\
+	    --sample=$sample_id \\
+	    --reference=$genome \\
+		--create-bam $create_bam \\
 		--localcores=19 --localmem=120 \\
 		 $forcecells $intron_argument
 

--- a/modules/cellranger/multi/main.nf
+++ b/modules/cellranger/multi/main.nf
@@ -13,10 +13,18 @@ process MULTI {
 		val project_id, emit: project_id
 		
 	script:
+
+	if ( params.create_bam == 'true' ) {
+		create_bam="true"
+	} else {
+		create_bam="false"
+	}
+
 	"""
 	cellranger multi \\
-	     --id=$sample_id \\
-         --csv=$config \\
+	    --id=$sample_id \\
+        --csv=$config \\
+		--create-bam $create_bam \\
 		--localcores=16 --localmem=120 \\
 
 	"""


### PR DESCRIPTION
## Background
v8.0.0 require that you choose `--create-bam <true|false>`, there is no deafult - this had been done in other PR #57  for another subprocess

## Problem/Issue
Cellranger crashed due to unassigned --create-bam flag in SCmulti
## What have I done
Now `--create-bam` will be false unless true is specified

## Check list
I have:
- [ ] Tested with Stub run
- [ ] Tested on our HPC
