### PR TITLE
added create-bam false

### DIFF
--- a/modules/multi_config/gen_flex_config/main.nf
+++ b/modules/multi_config/gen_flex_config/main.nf
@@ -29,6 +29,7 @@ process GEN_FLEX_CONFIG {
     echo \"\"\"[gene-expression]
     reference,$transcriptome
     probe-set,$probeset
+    create-bam,false
     [libraries]
     fastq_id,fastqs,feature_types
     $Sample_ID,$params.outdir/$Sample_Project/fastq,Gene Expression

--- a/modules/multi_config/gen_multi_config/main.nf
+++ b/modules/multi_config/gen_multi_config/main.nf
@@ -27,6 +27,7 @@ process GENERATE_MULTI_CONFIG{
         sample_name = Sample_ID[libtype.indexOf('gex')]
         gex_header+='[gene-expression]\n'
         gex_header+='reference,'+gex_ref+'\n'
+        gex_header+='create-bam,false\n'
     } else if (libtype.contains('adt')) {
         sample_name = Sample_ID[libtype.indexOf('adt')]
     } else if (libtype.contains('hto')) {


### PR DESCRIPTION
## Background
The new version of cellranger requires the create-bam variable to be defined.
## Problem/Issue
Pipeline crashes due to undefined variable create-bam
## What have I done
Added create-bam=false in the script where the config files for multi and flex are generated
## Check list
I have:
- [ ] Tested with Stub run
- [X] Tested on our HPC
